### PR TITLE
Expose helm.singleNamespace over the deployment-config query endpoint

### DIFF
--- a/src/resolvers/query/deployment-config/index.js
+++ b/src/resolvers/query/deployment-config/index.js
@@ -7,7 +7,7 @@ import { keyBy } from "lodash";
  * @param {Object} parent The result of the parent resolver.
  * @param {Object} args The graphql arguments.
  * @param {Object} ctx The graphql context.
- * @return {AuthConfig} The auth config.
+ * @return {DeploymentConfig} The deployment config.
  */
 export default async function deploymentConfig() {
   // Get astroUnit object directly from config.
@@ -28,12 +28,17 @@ export default async function deploymentConfig() {
   // Get current version of platform, passed from helm.
   const latestVersion = config.get("helm.releaseVersion");
 
+  // Are we deploying the platform and airflow into the same namespace (true),
+  // or creating a new namespace for each deployment (false)
+  const singleNamespace = config.get("helm.singleNamespace");
+
   return {
     defaults,
     limits,
     astroUnit,
     maxExtraAu,
     executors,
-    latestVersion
+    latestVersion,
+    singleNamespace
   };
 }

--- a/src/resolvers/query/deployment-config/index.unit.test.js
+++ b/src/resolvers/query/deployment-config/index.unit.test.js
@@ -36,6 +36,7 @@ const query = `
       maxExtraAu
       executors
       latestVersion
+      singleNamespace
     }
   }
 `;
@@ -51,5 +52,6 @@ describe("deploymentConfig", () => {
     expect(data.deploymentConfig).toHaveProperty("maxExtraAu");
     expect(data.deploymentConfig).toHaveProperty("executors");
     expect(data.deploymentConfig).toHaveProperty("latestVersion");
+    expect(data.deploymentConfig).toHaveProperty("singleNamespace");
   });
 });

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -123,6 +123,7 @@ type DeploymentConfig {
   maxExtraAu: Int
   executors: JSON
   latestVersion: String
+  singleNamespace: Boolean!
 }
 
 type AstroUnit {


### PR DESCRIPTION
This is needed by the Orbit UI to control what form components to show.

Part of https://github.com/astronomer/astronomer/issues/215